### PR TITLE
Add webpage for demonstrating font samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 This is a copy of Solbera's CC-BY-SA-4.0 fonts taken from [his Reddit thread](https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/), combined with Ryrok's fixes from [this Reddit thread](https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/).
 
-Here are updated versions of every 5th Edition font
-This is every font used in base 5th Edition, free of all restrictions.
-This contains contains 22 Fonts in 7 Families.
-
-They Have Unique Names Based on the Original Fonts Name.
+The following table contains names and usage details:
 
 | Original Font          | Solbera's Font         | [Usage](http://taxidermicowlbear.weebly.com/dd-fonts.html) |
 | ---------------------- | ---------------------- | ------ |
@@ -18,29 +14,39 @@ They Have Unique Names Based on the Original Fonts Name.
 | Dai Vernon Misdirect   | Zatanna Misdirection   | Titles of tables |
 | (unknown )             | Solbera Imitation      | Drop caps |
 
-I have received lots of messages regarding the fonts I have posted recently. So
-to respond to all the Questions or Remarks here is one thread.
+---
 
-> Q. Do you have any plans to update the other fonts to be Embeddable for Indesign
-   and other Programs?
-   
-A. Yes, this Package Contains Creative Commons Versions of Every Font used in
-   Base 5th edition.
-
-> Q. What is the Licensing on these fonts?
-
-A. I have created a clone and updated every font used in base 5th Edition.
-   All of my fonts are released as Creative Commons. In short, this means I
-   share them with the community on the condition that you share them as
-   well. You can read the licence [here](http://creativecommons.org/licenses/by-sa/4.0/). 
-   It is the standard [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
-
-> Q. Can I use these for my Program, Homebrew, or Anything
-
-A. Yes, but don't charge money for the fonts. These are free fonts!
-
-> Q. What do I do with these Fonts?
-
-A. Make Some Sweet Homebrew for the rest of us!
+> Here are updated versions of every 5th Edition font.
+>
+> This is every font used in base 5th Edition, free of all restrictions.
+>
+> This contains contains 22 Fonts in 7 Families.
+> 
+> They Have Unique Names Based on the Original Fonts Name.
+>
+> I have received lots of messages regarding the fonts I have posted recently. So
+> to respond to all the Questions or Remarks here is one thread.
+>    
+> > Q. Do you have any plans to update the other fonts to be Embeddable for Indesign
+>      and other Programs?
+>    
+> A. Yes, this Package Contains Creative Commons Versions of Every Font used in
+>    Base 5th edition.
+>
+> > Q. What is the Licensing on these fonts?
+>
+> A. I have created a clone and updated every font used in base 5th Edition.
+>    All of my fonts are released as Creative Commons. In short, this means I
+>    share them with the community on the condition that you share them as
+>    well. You can read the licence [here](http://creativecommons.org/licenses/by-sa/4.0/). 
+>    It is the standard [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+>
+> > Q. Can I use these for my Program, Homebrew, or Anything
+>
+> A. Yes, but don't charge money for the fonts. These are free fonts!
+>
+> > Q. What do I do with these Fonts?
+>
+> A. Make Some Sweet Homebrew for the rest of us!
 
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -1,63 +1,46 @@
 # Summary
 
-This is a copy of Solbera's CC-BY-SA-4.0 fonts taken from his Reddit thread:
-https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/
+This is a copy of Solbera's CC-BY-SA-4.0 fonts taken from [his Reddit thread](https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/), combined with Ryrok's fixes from [this Reddit thread](https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/).
 
-combined with Ryrok's fixes from:
-https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/
-
-# Solbera's original thread
-
-Here are Updated Versions of every 5th edition Font
-This is every Font Used in Base 5th Edition Free of All Restrictions. It
-Contains 22 Fonts in 7 Families.
+Here are updated versions of every 5th Edition font
+This is every font used in base 5th Edition, free of all restrictions.
+This contains contains 22 Fonts in 7 Families.
 
 They Have Unique Names Based on the Original Fonts Name.
 
-| Original Font          | Solbera's Font         |
-| ---------------------- | ---------------------- |
-| Scala Sans             | Scaly Sans             |
-| Scala Sans Caps        | Scaly Sans Caps        |
-| Modesto Bold Condensed | Nodesto Caps Condensed |
-| Mrs Eaves Small Caps   | Mr Eaves Small Caps    |
-| Bookmania              | Bookinsanity           |
-| Dai Vernon Misdirect   | Zatanna Misdirection   |
+| Original Font          | Solbera's Font         | [Usage](http://taxidermicowlbear.weebly.com/dd-fonts.html) |
+| ---------------------- | ---------------------- | ------ |
+| Scala Sans             | Scaly Sans             | Body text |
+| Scala Sans Caps        | Scaly Sans Caps        | Monster Manual quotes |
+| Modesto Bold Condensed | Nodesto Caps Condensed | Book and card titles |
+| Mrs Eaves Small Caps   | Mr Eaves Small Caps    | Headings |
+| Bookmania              | Bookinsanity           | Tables |
+| Dai Vernon Misdirect   | Zatanna Misdirection   | Titles of tables |
+| (unknown )             | Solbera Imitation      | Drop caps |
 
 I have received lots of messages regarding the fonts I have posted recently. So
 to respond to all the Questions or Remarks here is one thread.
 
-Q. Do you have any plans to update the other fonts to be Embeddable for Indesign
+> Q. Do you have any plans to update the other fonts to be Embeddable for Indesign
    and other Programs?
    
 A. Yes, this Package Contains Creative Commons Versions of Every Font used in
    Base 5th edition.
 
-Q. What is the Licensing on these fonts?
+> Q. What is the Licensing on these fonts?
 
-A. I have Created a Clone and Updated every font used In Base 5th Edition.
-   All of my fonts are released as Creative Commons. In Short this means I
-   Share them with the Community on the Condition that you Share them as
-   well. You can Read the Licence Here It is the standard Creative Commons
-   Attribution-ShareAlike 4.0 International License.
+A. I have created a clone and updated every font used in base 5th Edition.
+   All of my fonts are released as Creative Commons. In short, this means I
+   share them with the community on the condition that you share them as
+   well. You can read the licence [here](http://creativecommons.org/licenses/by-sa/4.0/). 
+   It is the standard [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
 
-Q. Can I use these for my Program, Homebrew, or Anything
+> Q. Can I use these for my Program, Homebrew, or Anything
 
-A. Yes, but don't charge money for the fonts. These are Free Fonts!
+A. Yes, but don't charge money for the fonts. These are free fonts!
 
-Q. What do I do with these Fonts?
+> Q. What do I do with these Fonts?
 
 A. Make Some Sweet Homebrew for the rest of us!
 
-# Ryrok's additions
-
-Hi all!
-
-/u/Solbera's awesome fonts had a couple errors in metadata that prevented them
-being installed on OS X. I've fixed the metadata on these fonts:
-
-* Bookinsanity
-* Bookinsanity Bold
-* ScalySans Bold Italic
-
-You can find them on drive.
-
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
 <p>This is a copy of Solbera's Creative Commons Attribution Share-Alike 4.0 fonts taken from <a href="https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/">this Reddit thread</a>, combined with Ryrok's fixes from <a href="https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/">this Reddit thread</a>.</p>
 
-<p>The fonts have unique names based on the Original fonts' names:</p>
+<p>The fonts have unique names based on the original fonts' names:</p>
 
 <table>
 	<thead>

--- a/index.html
+++ b/index.html
@@ -25,292 +25,296 @@
 		</style>
 	</head>
 	<body>
-		<h1>Solbera's DND 5e Fonts</h1>
-
-		<p>This is a copy of Solbera's Creative Commons Attribution Share-Alike 4.0 fonts taken from <a href="https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/">this Reddit thread</a>, combined with Ryrok's fixes from <a href="https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/">this Reddit thread</a>.</p>
-
-		<p>The fonts have unique names based on the Original fonts' names:</p>
-
-		<table>
-			<thead>
-				<tr>
-				<th>Original Font</th>
-				<th>Solbera's Font</th>
-				<th>Usage</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>Bookmania</td>
-					<td>Bookinsanity</td>
-					<td>Body text</td>
-				</tr>
-				<tr>
-					<td>Dai Vernon Misdirect</td>
-					<td>Zatanna Misdirection</td>
-					<td>Monster Manual quotes</td>
-				</tr>
-				<tr>
-					<td>Modesto Bold Condensed</td>
-					<td>Nodesto Caps Condensed</td>
-					<td>Book and card titles</td>
-				</tr>
-				<tr>
-					<td>Mrs Eaves Small Caps</td>
-					<td>Mr Eaves Small Caps</td>
-					<td>Headings</td>
-				</tr>
-				<tr>
-					<td>Scala Sans</td>
-					<td>Scaly Sans</td>
-					<td>Tables</td>
-				</tr>
-				<tr>
-					<td>Scala Sans Caps</td>
-					<td>Scaly Sans Caps</td>
-					<td>Titles of tables</td>
-				</tr>
-				<tr>
-					<td>(unknown)</td>
-					<td>Solbera Imitation</td>
-					<td>Drop caps</td>
-				</tr>
-			</tbody>
-		</table>
-
-		<p>This webpage represents the fonts in this GitHub repository as web fonts, using your browser's <a href="https://caniuse.com/#feat=ttf">OpenType font support</a>.</p>
 
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Bookinsanity";
-				src: url("/Bookinsanity/Bookinsanity.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
+<h1>Solbera's DND 5e Fonts</h1>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Bookinsanity Bold Italic";
-				src: url("/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
-				font-weight: bold;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
+<p>This is a copy of Solbera's Creative Commons Attribution Share-Alike 4.0 fonts taken from <a href="https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/">this Reddit thread</a>, combined with Ryrok's fixes from <a href="https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/">this Reddit thread</a>.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Bookinsanity Bold";
-				src: url("/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
-				font-weight: bold;
-				font-style: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold', serif; font-style: italic;">This text is in Bookinsanity Bold.</p>
+<p>The fonts have unique names based on the Original fonts' names:</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Bookinsanity Italic";
-				src: url("/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
-				font-weight: normal;
-				font-style: italic;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Bookinsanity Italic', serif; font-style: italic;">This text is in Bookinsanity Italic</p>
+<table>
+	<thead>
+		<tr>
+		<th>Original Font</th>
+		<th>Solbera's Font</th>
+		<th>Usage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Bookmania</td>
+			<td><a href="#bookinsanity">Bookinsanity</a></td>
+			<td>Body text</td>
+		</tr>
+		<tr>
+			<td>Dai Vernon Misdirect</td>
+			<td>Zatanna Misdirection</td>
+			<td>Monster Manual quotes</td>
+		</tr>
+		<tr>
+			<td>Modesto Bold Condensed</td>
+			<td>Nodesto Caps Condensed</td>
+			<td>Book and card titles</td>
+		</tr>
+		<tr>
+			<td>Mrs Eaves Small Caps</td>
+			<td>Mr Eaves Small Caps</td>
+			<td>Headings</td>
+		</tr>
+		<tr>
+			<td>Scala Sans</td>
+			<td>Scaly Sans</td>
+			<td>Tables</td>
+		</tr>
+		<tr>
+			<td>Scala Sans Caps</td>
+			<td>Scaly Sans Caps</td>
+			<td>Titles of tables</td>
+		</tr>
+		<tr>
+			<td>(unknown)</td>
+			<td>Solbera Imitation</td>
+			<td>Drop caps</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This webpage represents the fonts in this GitHub repository as web fonts, using your browser's <a href="https://caniuse.com/#feat=ttf">OpenType font support</a>.</p>
 
 
+<style id="bookinsanity" type="text/css">
+	@font-face {
+		font-family: "Bookinsanity";
+		src: url("/Bookinsanity/Bookinsanity.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
 
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity Bold Italic";
+		src: url("/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Zatanna Misdirection";
-				src: url("/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity Bold";
+		src: url("/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+		font-weight: bold;
+		font-style: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold', serif; font-style: italic;">This text is in Bookinsanity Bold. The Bard was sure e could get through the gate. All e had to do is convincinly explain why e was being followed by a bright yellow, vocally angry Flumph.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Zatanna Misdirection Bold Italic";
-				src: url("/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
-				font-weight: bold;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic.</p>
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Zatanna Misdirection Bold";
-				src: url("/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
-				font-weight: bold;
-				font-style: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif; font-style: italic;">This text is in Zatanna Misdirection Bold.</p>
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Zatanna Misdirection Italic";
-				src: url("/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
-				font-weight: normal;
-				font-style: italic;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Italic', serif; font-style: italic;">This text is in Zatanna Misdirection Italic</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity Italic";
+		src: url("/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+		font-weight: normal;
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity Italic', serif; font-style: italic;">This text is in Bookinsanity Italic. The Cleric gave up trying to speak with the Svirfneblin; they had tried Common, Undercommon, Elvish, Gnomish, Goblin, Sylvan, Orc and even Abyssal, but they could not get across to the tiny Svirfneblin the danger it was in.</p>
 
 
 
 
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection";
+		src: url("/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection. Yesterday the Druid had planted flowers in their garden. Today, they would defend the pumpkin patch against invaders.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Nodesto Caps Condensed";
-				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection Bold Italic";
+		src: url("/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic. The Fighter polished her sword. She was stalling for time; this battle would not be pleasant. Sibling rivalries never were.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Nodesto Caps Condensed Bold Italic";
-				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
-				font-weight: bold;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection Bold";
+		src: url("/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+		font-weight: bold;
+		font-style: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif; font-style: italic;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Nodesto Caps Condensed Bold";
-				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
-				font-weight: bold;
-				font-style: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold', serif; font-style: italic;">This text is in Nodesto Caps Condensed Bold.</p>
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Nodesto Caps Condensed Italic";
-				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
-				font-weight: normal;
-				font-style: italic;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Italic', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic</p>
-
-
-
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Mr Eaves Small Caps";
-				src: url("/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Mr Eaves Small Caps', serif;">This text is in Mr Eaves Small Caps.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection Italic";
+		src: url("/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+		font-weight: normal;
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Italic', serif; font-style: italic;">This text is in Zatanna Misdirection Italic. The Paladin had cracked. All they could think was the last words of eir opponent: "Only nothingness above."</p>
 
 
 
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans";
-				src: url("/Scaly Sans/Scaly Sans.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Bold Italic";
-				src: url("/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
-				font-weight: bold;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed";
+		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed. The Rogue was ready. So, so ready. now was the time for dancing, and her competitors would not see her coming.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Bold";
-				src: url("/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
-				font-weight: bold;
-				font-style: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; font-style: italic;">This text is in Scaly Sans Bold.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed Bold Italic";
+		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic. At long last, Luck was with the Sorceror. He had seen what the rest of the party had not, and quickly cast Snilloc's Snowball Storm to defend against the schoolchildren.</p>
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Italic";
-				src: url("/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
-				font-weight: normal;
-				font-style: italic;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Italic', serif; font-style: italic;">This text is in Scaly Sans Italic</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed Bold";
+		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+		font-weight: bold;
+		font-style: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold', serif; font-style: italic;">This text is in Nodesto Caps Condensed Bold. The Warlock's patron had brought em to a strange and desolate island, but eir task here was obvious. The castle on the central peak must be purged.</p>
 
-
-
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Caps";
-				src: url("/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps.</p>
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Caps Bold Italic";
-				src: url("/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
-				font-weight: bold;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic.</p>
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Caps Bold";
-				src: url("/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
-				font-weight: bold;
-				font-style: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif; font-style: italic;">This text is in Scaly Sans Caps Bold.</p>
-
-		<style type="text/css">
-			@font-face {
-				font-family: "Scaly Sans Caps Italic";
-				src: url("/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
-				font-weight: normal;
-				font-style: italic;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Italic', serif; font-style: italic;">This text is in Scaly Sans Caps Italic</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed Italic";
+		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+		font-weight: normal;
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Italic', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic. The Wizard was running late. She'd missed the last ferry to the city, and though she had been able to procure a kayak, her lack of proficiency with it was rapidly drawing her towards the city's waterfall.</p>
 
 
 
 
-		<style type="text/css">
-			@font-face {
-				font-family: "Solbera Imitation";
-				src: url("/Solbera Imitation/Solbera Imitation.otf") format("opentype");
-				font-weight: normal;
-			}
-		</style>
-		<p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation.</p>
+<style type="text/css">
+	@font-face {
+		font-family: "Mr Eaves Small Caps";
+		src: url("/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Mr Eaves Small Caps', serif;">This text is in Mr Eaves Small Caps. In a hole in the ground there lived a Halfling, for he had not yet heard the call of adventure. That would come next week, when the tavern burned down.</p>
 
-		<footer>
-			<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-		</footer>
+
+
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans";
+		src: url("/Scaly Sans/Scaly Sans.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans. The dragon was discontent, for its entire horde had disappeared while it was out hunting. It suspected the local fishermen, and set out to steal their boats.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Bold Italic";
+		src: url("/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic. It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Bold";
+		src: url("/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+		font-weight: bold;
+		font-style: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; font-style: italic;">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Italic";
+		src: url("/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+		font-weight: normal;
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Italic', serif; font-style: italic;">This text is in Scaly Sans Italic. If one more traveling writer asked the Hermit what life was like atop her pole, she swore she would climb down, uproot her pole, drag it into the city where the writers came from, and spit their leader upon its sharpened point.</p>
+
+
+
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps";
+		src: url("/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps. This Urchin had grown up on the streets alone, until this Urchin forged a family. Now, these Urchins ruled seven city blocks. Soon, they would be big enough to take on the City Guard.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps Bold Italic";
+		src: url("/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic. The Charlatan was bored, bored, bored. He'd been stuck on this rock for seventeen days after being thrown overboard by the pirates. Was that a sail on the horizon? No, probably just a wisp of cloud.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps Bold";
+		src: url("/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+		font-weight: bold;
+		font-style: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif; font-style: italic;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps Italic";
+		src: url("/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+		font-weight: normal;
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Italic', serif; font-style: italic;">This text is in Scaly Sans Caps Italic. The Weapon Master was also a blacksmith, which was helpful when a roving party came to town, flush with money, looking for upgraded blades. They wanted swords? She had swords. Lots of swords.</p>
+
+
+
+
+<style type="text/css">
+	@font-face {
+		font-family: "Solbera Imitation";
+		src: url("/Solbera Imitation/Solbera Imitation.otf") format("opentype");
+		font-weight: normal;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation. If you can read this text, talk to the priest of the smallest temple in the city.</p>
+
+<footer>
+	<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+</footer>
+
+
 
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE HTML>
+<html lang="en-us">
+	<head>
+		<style type="text/css">
+			body style {
+				display: block;
+				border: 1px solid black;
+				padding: 0 1em;
+				font-family: monospace;
+				white-space: pre;
+				overflow-x: scroll;
+				background-color: #eee;
+			}
+
+			p.demo {
+				font-size: 2rem;
+			}
+			p + style {
+				margin-top: 4rem;
+			}
+
+			footer {
+				text-align: center;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Solbera's DND 5e Fonts</h1>
+
+		<p>This is a copy of Solbera's Creative Commons Attribution Share-Alike 4.0 fonts taken from <a href="https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/">this Reddit thread</a>, combined with Ryrok's fixes from <a href="https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/">this Reddit thread</a>.</p>
+
+		<p>The fonts have unique names based on the Original fonts' names:</p>
+
+		<table>
+			<thead>
+				<tr>
+				<th>Original Font</th>
+				<th>Solbera's Font</th>
+				<th>Usage</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Bookmania</td>
+					<td>Bookinsanity</td>
+					<td>Body text</td>
+				</tr>
+				<tr>
+					<td>Dai Vernon Misdirect</td>
+					<td>Zatanna Misdirection</td>
+					<td>Monster Manual quotes</td>
+				</tr>
+				<tr>
+					<td>Modesto Bold Condensed</td>
+					<td>Nodesto Caps Condensed</td>
+					<td>Book and card titles</td>
+				</tr>
+				<tr>
+					<td>Mrs Eaves Small Caps</td>
+					<td>Mr Eaves Small Caps</td>
+					<td>Headings</td>
+				</tr>
+				<tr>
+					<td>Scala Sans</td>
+					<td>Scaly Sans</td>
+					<td>Tables</td>
+				</tr>
+				<tr>
+					<td>Scala Sans Caps</td>
+					<td>Scaly Sans Caps</td>
+					<td>Titles of tables</td>
+				</tr>
+				<tr>
+					<td>(unknown)</td>
+					<td>Solbera Imitation</td>
+					<td>Drop caps</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<p>This webpage represents the fonts in this GitHub repository as web fonts, using your browser's <a href="https://caniuse.com/#feat=ttf">OpenType font support</a>.</p>
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Bookinsanity";
+				src: url("/Bookinsanity/Bookinsanity.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Bookinsanity Bold Italic";
+				src: url("/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+				font-weight: bold;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Bookinsanity Bold";
+				src: url("/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+				font-weight: bold;
+				font-style: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold', serif; font-style: italic;">This text is in Bookinsanity Bold.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Bookinsanity Italic";
+				src: url("/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+				font-weight: normal;
+				font-style: italic;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Bookinsanity Italic', serif; font-style: italic;">This text is in Bookinsanity Italic</p>
+
+
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Zatanna Misdirection";
+				src: url("/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Zatanna Misdirection Bold Italic";
+				src: url("/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+				font-weight: bold;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Zatanna Misdirection Bold";
+				src: url("/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+				font-weight: bold;
+				font-style: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif; font-style: italic;">This text is in Zatanna Misdirection Bold.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Zatanna Misdirection Italic";
+				src: url("/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+				font-weight: normal;
+				font-style: italic;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Italic', serif; font-style: italic;">This text is in Zatanna Misdirection Italic</p>
+
+
+
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Nodesto Caps Condensed";
+				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Nodesto Caps Condensed Bold Italic";
+				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+				font-weight: bold;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Nodesto Caps Condensed Bold";
+				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+				font-weight: bold;
+				font-style: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold', serif; font-style: italic;">This text is in Nodesto Caps Condensed Bold.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Nodesto Caps Condensed Italic";
+				src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+				font-weight: normal;
+				font-style: italic;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Italic', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic</p>
+
+
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Mr Eaves Small Caps";
+				src: url("/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Mr Eaves Small Caps', serif;">This text is in Mr Eaves Small Caps.</p>
+
+
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans";
+				src: url("/Scaly Sans/Scaly Sans.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Bold Italic";
+				src: url("/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+				font-weight: bold;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Bold";
+				src: url("/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+				font-weight: bold;
+				font-style: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; font-style: italic;">This text is in Scaly Sans Bold.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Italic";
+				src: url("/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+				font-weight: normal;
+				font-style: italic;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Italic', serif; font-style: italic;">This text is in Scaly Sans Italic</p>
+
+
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Caps";
+				src: url("/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Caps Bold Italic";
+				src: url("/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+				font-weight: bold;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Caps Bold";
+				src: url("/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+				font-weight: bold;
+				font-style: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif; font-style: italic;">This text is in Scaly Sans Caps Bold.</p>
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Scaly Sans Caps Italic";
+				src: url("/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+				font-weight: normal;
+				font-style: italic;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Italic', serif; font-style: italic;">This text is in Scaly Sans Caps Italic</p>
+
+
+
+
+		<style type="text/css">
+			@font-face {
+				font-family: "Solbera Imitation";
+				src: url("/Solbera Imitation/Solbera Imitation.otf") format("opentype");
+				font-weight: normal;
+			}
+		</style>
+		<p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation.</p>
+
+		<footer>
+			<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+		</footer>
+
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
 <style id="bookinsanity" type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("/Bookinsanity/Bookinsanity.otf") format("opentype");
+		src: url("./Bookinsanity/Bookinsanity.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>
@@ -98,7 +98,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity Bold Italic";
-		src: url("/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+		src: url("./Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -107,7 +107,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity Bold";
-		src: url("/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
 		font-weight: bold;
 		font-style: normal;
 	}
@@ -117,7 +117,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity Italic";
-		src: url("/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
 		font-weight: normal;
 		font-style: italic;
 	}
@@ -130,7 +130,7 @@
 <style id="zatanna" type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+		src: url("./Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>
@@ -139,7 +139,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection Bold Italic";
-		src: url("/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -148,7 +148,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection Bold";
-		src: url("/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
 		font-weight: bold;
 		font-style: normal;
 	}
@@ -158,7 +158,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection Italic";
-		src: url("/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
 		font-weight: normal;
 		font-style: italic;
 	}
@@ -172,7 +172,7 @@
 <style id="nodesto" type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>
@@ -181,7 +181,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed Bold Italic";
-		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -190,7 +190,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed Bold";
-		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
 		font-weight: bold;
 		font-style: normal;
 	}
@@ -200,7 +200,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed Italic";
-		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
 		font-weight: normal;
 		font-style: italic;
 	}
@@ -213,7 +213,7 @@
 <style id="eaves"type="text/css">
 	@font-face {
 		font-family: "Mr Eaves Small Caps";
-		src: url("/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+		src: url("./Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>
@@ -225,7 +225,7 @@
 <style id="scaly" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("/Scaly Sans/Scaly Sans.otf") format("opentype");
+		src: url("./Scaly Sans/Scaly Sans.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>
@@ -234,7 +234,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Bold Italic";
-		src: url("/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+		src: url("./Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -243,7 +243,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Bold";
-		src: url("/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+		src: url("./Scaly Sans/Scaly Sans Bold.otf") format("opentype");
 		font-weight: bold;
 		font-style: normal;
 	}
@@ -253,7 +253,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Italic";
-		src: url("/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+		src: url("./Scaly Sans/Scaly Sans Italic.otf") format("opentype");
 		font-weight: normal;
 		font-style: italic;
 	}
@@ -266,7 +266,7 @@
 <style id="scalycaps" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+		src: url("./Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>
@@ -275,7 +275,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps Bold Italic";
-		src: url("/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -284,7 +284,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps Bold";
-		src: url("/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
 		font-weight: bold;
 		font-style: normal;
 	}
@@ -294,7 +294,7 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps Italic";
-		src: url("/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
 		font-weight: normal;
 		font-style: italic;
 	}
@@ -307,7 +307,7 @@
 <style id="solbera" type="text/css">
 	@font-face {
 		font-family: "Solbera Imitation";
-		src: url("/Solbera Imitation/Solbera Imitation.otf") format("opentype");
+		src: url("./Solbera Imitation/Solbera Imitation.otf") format("opentype");
 		font-weight: normal;
 	}
 </style>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
 				text-align: center;
 			}
 		</style>
+
+		<title>Solbera's Dungeons and Dragons Fifth Edition Fonts</title>
+		<meta name="description" content="A dingus to show Solbera's 22 DND 5e font faces, released uncer CC-BY-SA 4.0">
 	</head>
 	<body>
 

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 		font-style: normal;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif; font-style: italic;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
 
 <style type="text/css">
 	@font-face {
@@ -236,6 +236,7 @@
 		font-family: "Scaly Sans Bold Italic";
 		src: url("./Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
 		font-weight: bold;
+		font-style: italic;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic. It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.</p>
@@ -248,7 +249,7 @@
 		font-style: normal;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; font-style: italic;">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; ">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
 
 <style type="text/css">
 	@font-face {
@@ -289,7 +290,7 @@
 		font-style: normal;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif; font-style: italic;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
 
 <style type="text/css">
 	@font-face {

--- a/index.html
+++ b/index.html
@@ -52,32 +52,32 @@
 		</tr>
 		<tr>
 			<td>Dai Vernon Misdirect</td>
-			<td>Zatanna Misdirection</td>
+			<td><a href="#zatanna">Zatanna Misdirection</a></td>
 			<td>Monster Manual quotes</td>
 		</tr>
 		<tr>
 			<td>Modesto Bold Condensed</td>
-			<td>Nodesto Caps Condensed</td>
+			<td><a href="#nodesto">Nodesto Caps Condensed</a></td>
 			<td>Book and card titles</td>
 		</tr>
 		<tr>
 			<td>Mrs Eaves Small Caps</td>
-			<td>Mr Eaves Small Caps</td>
+			<td><a href="#eaves">Mr Eaves Small Caps</a></td>
 			<td>Headings</td>
 		</tr>
 		<tr>
 			<td>Scala Sans</td>
-			<td>Scaly Sans</td>
+			<td><a href="#scaly">Scaly Sans</a></td>
 			<td>Tables</td>
 		</tr>
 		<tr>
 			<td>Scala Sans Caps</td>
-			<td>Scaly Sans Caps</td>
+			<td><a href="#scalycaps">Scaly Sans Caps</a></td>
 			<td>Titles of tables</td>
 		</tr>
 		<tr>
 			<td>(unknown)</td>
-			<td>Solbera Imitation</td>
+			<td><a href="#solbera">Solbera Imitation</a></td>
 			<td>Drop caps</td>
 		</tr>
 	</tbody>
@@ -127,7 +127,7 @@
 
 
 
-<style type="text/css">
+<style id="zatanna" type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
 		src: url("/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
@@ -169,7 +169,7 @@
 
 
 
-<style type="text/css">
+<style id="nodesto" type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
 		src: url("/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
@@ -210,7 +210,7 @@
 
 
 
-<style type="text/css">
+<style id="eaves"type="text/css">
 	@font-face {
 		font-family: "Mr Eaves Small Caps";
 		src: url("/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
@@ -222,7 +222,7 @@
 
 
 
-<style type="text/css">
+<style id="scaly" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
 		src: url("/Scaly Sans/Scaly Sans.otf") format("opentype");
@@ -263,7 +263,7 @@
 
 
 
-<style type="text/css">
+<style id="scalycaps" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
 		src: url("/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
@@ -304,7 +304,7 @@
 
 
 
-<style type="text/css">
+<style id="solbera" type="text/css">
 	@font-face {
 		font-family: "Solbera Imitation";
 		src: url("/Solbera Imitation/Solbera Imitation.otf") format("opentype");


### PR DESCRIPTION
## Changes

- Cleans up README:
    - Removes the "Original post" presentation
    - Updates the font table to provide sample usages
    - Standardizes capitalization of words
    - Adds a Creative Commons logo and links to the cited license
- Adds `index.html` for publishing as [a GitHub page](https://pages.github.com/). THere's a copy live in my repo at https://benlk.github.io/solbera-dnd-fonts/ but I thought you'd like one for this repo.
    - Demonstrates all fonts as OTF web fonts
    - Includes editable demo text
    - Includes copyable CSS samples for using these fonts in your own work.

## Why

- Cleans up the README to make it more useful.
- Adds a dingus page so people can preview the fonts.